### PR TITLE
Port over to using hyper instead of rust-http, because it is deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,9 @@ name = "witd"
 version = "0.0.1"
 authors = ["martin <martin@wit.ai", "oliv <oliv@wit.ai>", "willy <willy@wit.ai>"]
 
-[dependencies.http]
-git = "https://github.com/chris-morgan/rust-http"
+[dependencies.hyper]
+git = "https://github.com/hyperium/hyper.git"
 
 [dependencies.libwit]
 git = "https://github.com/wit-ai/libwit.git"
+


### PR DESCRIPTION
rust-http is a deprecated library, hyper is one the primary replacements.

hyper is slightly less stable than rust-http, but it is under more
active development and provides a much nicer API than rust-http.

Most of hyper's most important APIs, such as basic header setting,
status, and writing to the body of a response are already basically
stabilized.
